### PR TITLE
Add neomake

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -113,7 +113,7 @@ call plug#begin("$VIMHOME/plugged")
   Plug 'kevinoid/vim-jsonc'
   Plug 'jremmen/vim-ripgrep', { 'on': ['Rg', 'RgRoot'] }
   Plug 'junegunn/fzf', { 'on': ['FZF', '<Plug>fzf#run', '<Plug>fzf#wrap'] }
-  Plug 'junegunn/fzf.vim',
+  Plug 'junegunn/fzf.vim'
   Plug 'sheerun/vim-polyglot'
   Plug 'adelarsq/vim-matchit'
   Plug 'vim-airline/vim-airline'

--- a/vimrc
+++ b/vimrc
@@ -231,9 +231,11 @@ augroup PsoxFileAutos
   autocmd!
   autocmd FileType rust let g:autofmt_autosave = 1
   autocmd FileType yaml setlocal indentkeys-=<:> ts=8 sts=2 sw=2 expandtab
-  autocmd FileType go   setlocal ts=8 sts=4 sw=4 noexpandtab
+  autocmd FileType go   setlocal ts=8 sts=4 sw=4 noexpandtab 
+        \| autocmd BufWritePre <buffer> silent %!gofmt
   " Tidy nerdtree windiw
   autocmd FileType nerdtree setlocal nocursorcolumn nonumber norelativenumber signcolumn=no
+  " Autoinstall absent plugins
   autocmd VimEnter *
         \  if len(filter(values(g:plugs), '!isdirectory(v:val.dir)'))
         \| PlugInstall --sync

--- a/vimrc
+++ b/vimrc
@@ -85,17 +85,21 @@ endif
 
 exec "set rtp=$VIMHOME," . &rtp
 
+" Better if check for loading plugins
+" This one won't cause vim-plug to autodelete 'unloaded' plugins
 function! LoadIf(check, ...)
   let opts = get(a:000, 0, {})
   " Use opts, or default to not loading plugin
   return a:check ? opts : extend(opts, { 'on': [], 'for': [] })
 endfunction
 
+" Check if we can use async Syntastic
 let useNeomake = has('nvim') || v:version > 800
 
 call SourceIfExists(g:rc_files['pre'])
 call plug#begin("$VIMHOME/plugged")
   Plug 'junegunn/vim-easy-align'
+  Plug 'tmsvg/pear-tree'
   Plug 'tpope/vim-sensible'
   Plug 'tpope/vim-fugitive'
   Plug 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' }
@@ -123,6 +127,7 @@ call plug#begin("$VIMHOME/plugged")
   Plug 'neoclide/coc.nvim', { 'branch': 'release' }
   Plug 'scrooloose/syntastic', LoadIf(!useNeomake)
   Plug 'neomake/neomake', LoadIf(useNeomake)
+  Plug 'romainl/vim-qf', LoadIf(useNeomake)
 
   Plug 'roxma/nvim-yarp', LoadIf(has('nvim'))
   Plug 'roxma/vim-hug-neovim-rpc', LoadIf(has('nvim'))
@@ -168,14 +173,16 @@ augroup PsoxNERDTree
 augroup END
 
 if useNeomake
+  " Don't move cursor into qf/loc on open
   let g:neomake_open_list = 2
+  " Allow multiple makers to resolve
   let g:neomake_serialize = 1
   let g:neomake_serialize_abort_on_error = 1
   " Run on write (instant) + read (800ms) buffers
   call neomake#configure#automake('rw', 800)
 
+  " Disable inherited syntastic if it exists
   if has_key(plugs, 'syntastic')
-    " Disable inherited syntastic
     let g:syntastic_mode_map = {
       \ "mode": "passive",
       \ "active_filetypes": [],
@@ -183,6 +190,7 @@ if useNeomake
   endif
 endif
 
+" If we can't use Neomake, fall back to Syntastic
 if !useNeomake
   " Syntastic Settings
   " Note that airline automatically configures these
@@ -196,9 +204,26 @@ if !useNeomake
   let g:syntastic_enable_bash_checker = 1
 endif
 
+" vim-qf
+if has_key(plugs, 'vim-qf')
+  " Don't force qf/loc windows to bottom
+  let g:qf_window_bottom = 0
+  let g:qf_loclist_window_bottom = 0
+
+  " Let Neomake control window size
+  if useNeomake
+    let g:qf_auto_resize = 0
+  endif
+endif
+  
 " ripgrep settings
 let g:rg_highlight = 'true'
 let g:rg_derive_root = 'true'
+
+" Balance pairs when on open, close and delete
+let g:pear_tree_smart_openers = 1
+let g:pear_tree_smart_closers = 1
+let g:pear_tree_smart_backspace = 1
 
 " Other
 let g:rainbow_active = 1
@@ -206,6 +231,7 @@ augroup PsoxFileAutos
   autocmd!
   autocmd FileType rust let g:autofmt_autosave = 1
   autocmd FileType yaml setlocal indentkeys-=<:> ts=8 sts=2 sw=2 expandtab
+  autocmd FileType go   setlocal ts=8 sts=4 sw=4 noexpandtab
   " Tidy nerdtree windiw
   autocmd FileType nerdtree setlocal nocursorcolumn nonumber norelativenumber signcolumn=no
   autocmd VimEnter *

--- a/zshrc
+++ b/zshrc
@@ -114,7 +114,7 @@ plugins=(
   common-aliases 
   colored-man-pages 
 )
-( which git &>/dev/null ) && plugins+=( git git-extras git-flow-avh ) #&& [[ "$ZSH_THEME" == "stemmet" ]] && plugins+=( git-prompt )
+( which git &>/dev/null ) && plugins+=( git git-extras git-flow-avh ) && [[ "$ZSH_THEME" == "stemmet" ]] && [ -z "$STARSHIP_SHELL" ] && plugins+=( git-prompt )
 ( which perl &>/dev/null ) && plugins+=( perl )
 ( which go &>/dev/null ) && plugins+=( golang )
 ( which oc &>/dev/null ) && plugins+=( oc )

--- a/zshrc
+++ b/zshrc
@@ -114,7 +114,7 @@ plugins=(
   common-aliases 
   colored-man-pages 
 )
-( which git &>/dev/null ) && plugins+=( git git-extras git-flow-avh ) && [[ "$ZSH_THEME" == "stemmet" ]] && plugins+=( git-prompt )
+( which git &>/dev/null ) && plugins+=( git git-extras git-flow-avh ) #&& [[ "$ZSH_THEME" == "stemmet" ]] && plugins+=( git-prompt )
 ( which perl &>/dev/null ) && plugins+=( perl )
 ( which go &>/dev/null ) && plugins+=( golang )
 ( which oc &>/dev/null ) && plugins+=( oc )


### PR DESCRIPTION
Move to `neomake` which uses async loaders for file checking. This replaces `Syntastic`, which can freeze when running loaders making vim unresponsive.

Additionally this PR adds:

- `vim-qf` -- For auto-closing qf/loc windows similar to `Syntastic`
- `pear-tree` -- A smart bracket (and other pairs) closer
- `go`lang autocmd support for tabs and fmt-on-write
- Better `vim-plug` conditional loading
- Backwards compatibility with older versions of vim that don't support `neomake` (reverting to using `Syntastic`)
- Better checking for `starship` prompts in zsh git-prompt