### PR TITLE
Feature/tmux/fragments

### DIFF
--- a/tmux/fragment/plugins.conf
+++ b/tmux/fragment/plugins.conf
@@ -1,0 +1,70 @@
+# Default plugins list. By default this file is symlinked into ~/.config/tmux/plugins.conf.
+#
+# If you wish to change your plugin list, remove the symlink and add your own plugins.
+# You can copy this file in as a starting point via:
+#
+#   cp -vf "$PSOXIZSH/tmux/fragment/plugins.conf" ~/.config/tmux/plugins.conf
+#
+# If you'd like to check out the available plugins the following git repo keeps a list
+#
+#   github.com/tmux-plugins/list
+
+# ===== PLUGINS =====
+
+# This must always come first in the plugin list
+set -g @plugin 'tmux-plugins/tpm'
+
+# === Prefix highlight
+# Flashes a small indicator when {prefix} is hit, or when in certain tmux modes
+
+set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
+
+# Options
+set -g @prefix_highlight_prefix_prompt 'Pre'                    # default is 'Wait'
+set -g @prefix_highlight_fg 'yellow'                            # default is 'colour231'
+set -g @prefix_highlight_bg 'default'                           # default is 'colour04'
+# set -g @prefix_highlight_show_copy_mode 'on'                    # display prefix in copy mode
+# set -g @prefix_highlight_copy_prompt 'Copy'                     # copy display text
+# set -g @prefix_highlight_copy_mode_attr 'fg=default,bg=yellow'  # copy colors
+# set -g @prefix_highlight_show_sync_mode 'on'                    # display prefix in window sync mode
+# set -g @prefix_highlight_sync_prompt 'Sync'                     # sync display text
+# set -g @prefix_highlight_sync_mode_attr 'fg=default,bg=yellow'  # sync colors
+# set -g @prefix_highlight_output_prefix '< '                     # static prefix to add to prompt
+# set -g @prefix_highlight_output_suffix ' >'                     # static suffix to add to prompt
+# set -g @prefix_highlight_empty_has_affixes 'off'                # switch to 'on' to allow affixes on empty prompts
+# set -g @prefix_highlight_empty_prompt 'Tmux'                    # placeholder text when prompt isn't in use
+# set -g @prefix_highlight_empty_attr 'fg=default,bg=default'     # empty colors
+# ===
+
+# === Copycat
+# Provides quick and easy keyboard text search and copying to
+# tmux buffers
+
+set -g @plugin 'tmux-plugins/tmux-copycat'
+
+# Options
+# set -g @copycat_search '/'          # basic
+# set -g @copycat_git_special 'C-g'   # git (SHA)
+# set -g @copycat_file_search 'C-f'   # file path
+# set -g @copycat_url_search 'C-u'    # URL
+# set -g @copycat_digit_search 'C-d'  # number
+# set -g @copycat_hash_search 'C-h'   # hash
+# set -g @copycat_ip_search 'C-i'     # IP
+# ===
+
+# === Yank
+# Expands on Copycat adding keybinds for yanking into the system
+# clipboard. Requires OS specific clipboard managers.
+
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+# Options
+# set -g @override_copy_command 'my-clipboard-copy --some-arg'  # overide the default copy command, must accept input to stdin
+# set -g @yank_selection 'clipboard'                            # or 'primary' or 'secondary'
+# set -g @yank_selection_mouse 'clipboard'                      # or 'primary' or 'secondary'
+# set -g @yank_action 'copy-pipe-and-cancel'                    # or 'copy-pipe' to remain in copy mode after yanking
+# set -g @yank_with_mouse 'on'                                  # or 'off' by default yank will copy mouse selected text
+# ===
+
+# vim: filetype=tmux
+

--- a/tmux/fragment/vim-movement.conf
+++ b/tmux/fragment/vim-movement.conf
@@ -1,0 +1,34 @@
+# This fragmenet is meant to be used with a Vim plugin and provides unified movement
+# between Vim window/panes and tmux panes. It requires you install the following in
+# Vim to function correctly:
+#
+#   github.com/christoomey/vim-tmux-navigator
+#
+# Include it by adding the following snippet to your early (or late) tmux.conf:
+#
+#   source-file "$PSOXIZSH/tmux/fragment/vim-movement.conf"
+
+# Checks for if we're inside a Vim/FZF window
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+| grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+is_fzf="ps -o state= -o comm= -t '#{pane_tty}' \
+| grep -iqE '^[^TXZ ]+ +(\\S+\\/)?fzf$'"
+
+# Binds Ctrl-<h,j,k,l> to left,down,up,right movements
+bind -n C-h run "($is_vim && tmux send-keys C-h) \
+                || tmux select-pane -L"
+bind -n C-j run "($is_vim && tmux send-keys C-j) \
+                || ($is_fzf && tmux send-keys C-j) \
+                || tmux select-pane -D"
+bind -n C-k run "($is_vim && tmux send-keys C-k) \
+                || ($is_fzf && tmux send-keys C-k)  \
+                || tmux select-pane -U"
+bind -n C-l run "($is_vim && tmux send-keys C-l) \
+                || tmux select-pane -R"
+bind-key -T copy-mode-vi 'C-h' select-pane -L
+bind-key -T copy-mode-vi 'C-j' select-pane -D
+bind-key -T copy-mode-vi 'C-k' select-pane -U
+bind-key -T copy-mode-vi 'C-l' select-pane -R
+
+# Rebinds pane clear which overwritten by the above to {prefix} Ctrl-l
+bind C-l send-keys 'C-l'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,32 +1,12 @@
 # Plugins
 set-environment -g TMUX_PLUGIN_MANAGER_PATH "$TMUX_PLUGINS"
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
-set -g @prefix_highlight_prefix_prompt 'Pre'
-set -g @prefix_highlight_fg 'yellow'
-set -g @prefix_highlight_bg 'default'
-set -g @plugin 'tmux-plugins/tmux-copycat'
-set -g @plugin 'tmux-plugins/tmux-yank'
+if "test -f ~/.config/tmux/plugins.conf" {
+  source-file ~/.config/tmux/plugins.conf
+}
 
-# Integration with vim-tmux-navigator & fzf
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-| grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-is_fzf="ps -o state= -o comm= -t '#{pane_tty}' \
-| grep -iqE '^[^TXZ ]+ +(\\S+\\/)?fzf$'"
-bind -n C-h run "($is_vim && tmux send-keys C-h) \
-                || tmux select-pane -L"
-bind -n C-j run "($is_vim && tmux send-keys C-j) \
-                || ($is_fzf && tmux send-keys C-j) \
-                || tmux select-pane -D"
-bind -n C-k run "($is_vim && tmux send-keys C-k) \
-                || ($is_fzf && tmux send-keys C-k)  \
-                || tmux select-pane -U"
-bind -n C-l run "($is_vim && tmux send-keys C-l) \
-                || tmux select-pane -R"
-bind-key -T copy-mode-vi 'C-h' select-pane -L
-bind-key -T copy-mode-vi 'C-j' select-pane -D
-bind-key -T copy-mode-vi 'C-k' select-pane -U
-bind-key -T copy-mode-vi 'C-l' select-pane -R
+if "test -f ~/.config/tmux/early.conf" {
+  source-file ~/.config/tmux/early.conf
+}
 
 set-option -g prefix C-a
 set-option -g set-titles on
@@ -68,6 +48,10 @@ bind - last-window \; swap-pane -s tmux-zoom.0 \; kill-window -t tmux-zoom
 
 # prefix + / to search
 bind-key / copy-mode \; send-key ?
+
+if "test -f ~/.config/tmux/late.conf" {
+  source-file ~/.config/tmux/late.conf
+}
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run -b "$TMUX_PLUGINS/tpm/tpm"

--- a/zshrc
+++ b/zshrc
@@ -195,21 +195,19 @@ source $PSOXIZSH/zsh-custom/zshnip/zshnip.zsh
 
 # Set zsh tmux config path
 if which tmux &>/dev/null; then
-  for tmux_config in {~/.config/tmux,~/.tmux,/etc/tmux}; do
-    if [ -d "$tmux_config" ]; then
-      TMUX_PATH="$tmux_config"
-      break
-    fi
-  done
-
   [ -z "$TMUX_PATH" ] && TMUX_PATH=~/.config/tmux
-  export TMUX_PATH=$TMUX_PATH
 
-  [ -d "$TMUX_PATH" ] && [ -d "$TMUX_PATH/plugins" ] || { mkdir -vp $TMUX_PATH && cp -r $PSOXIZSH/tmux/. $TMUX_PATH }
-  # If a .conf is detected override the default zsh tmux path
-  [ -f "$TMUX_PATH/tmux.conf" ] && export ZSH_TMUX_CONFIG="$TMUX_PATH/tmux.conf"
+  # Bootstrap the user's plugin directory, if required
+  [ -d "$TMUX_PATH/plugins" ] || { mkdir -vp "$TMUX_PATH/plugins" && cp -r "$PSOXIZSH/tmux/plugins" "$TMUX_PATH/plugins" }
 
-  export TMUX_PLUGINS="$TMUX_PATH/plugins"
+  # Both tmux and TPM are very opininated about where configs must live,
+  # and TPM will only expand one layer of source-file directives, so we
+  # symlink the base config to the user local config file, if it doesn't
+  # exist.
+  [ ! -f ~/.tmux.conf ] && ln -s $PSOXIZSH/tmux/tmux.conf ~/.tmux.conf
+  [ ! -f "$TMUX_PATH/plugins.conf" ] && ln -s "$PSOXIZSH/tmux/fragment/plugins.conf" "$TMUX_PATH/plugins.conf"
+
+  export TMUX_PATH=$TMUX_PATH TMUX_PLUGINS="$TMUX_PATH/plugins" TMUX_CONFIG=~/.tmux.conf
 fi
 
 if which fzf &>/dev/null; then


### PR DESCRIPTION
This PR refactors tmux integration, providing a default `.conf` @`~/.tmux.conf` that sources configs in:

- `~/.config/tmux/plugins.conf`
- `~/.config/tmux/early.conf`
- `~/.config/tmux/late.conf`

It introduces `$PSOXIZSH/tmux/fragment`s which may contain optional, opinionated settings that users can include if they so choose. This PR provides two such fragments, `plugins` and `vim-movement` which were largely split out of the previous monolith `tmux.conf`. `fragment/plugins` is included by default via a symlink to `~/.config/tmux/plugins.conf`, though users may replace it as they choose.