### PR TITLE
Updated plugin from osx to macos

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -102,7 +102,7 @@ plugins=(
 ( which kubectl &>/dev/null ) && plugins+=( kubectl )
 ( [[ -e /etc/arch-release ]] ) && plugins+=( archlinux )
 ( [[ -e /etc/suse-release ]] ) && plugins+=( suse )
-( [[ "$(uname)" == "Darwin" ]] ) && plugins+=( osx )
+( [[ "$(uname)" == "Darwin" ]] ) && plugins+=( macos )
 #( which vim &>/dev/null ) && plugins+=( vim-interaction )
 ( which ssh &>/dev/null ) && [[ -d ~/.ssh ]] && plugins+=( ssh-agent )
 plugins+=( 


### PR DESCRIPTION
Fix for the warning
```
The `osx` plugin is deprecated and has been renamed to `macos`.
Please update your .zshrc to use the `macos` plugin instead.
```