### PR TITLE
Add lua configuration for Neovim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,3 @@
+vim.opt.rtp:append( os.getenv('PSOXIZSH') .. '/nvim' )
+
+require 'psoxizsh'

--- a/nvim/lua/psoxizsh/autocmd.lua
+++ b/nvim/lua/psoxizsh/autocmd.lua
@@ -1,0 +1,126 @@
+
+local M = { mt = {} }
+local Groups = {}
+local Group = { mt = {} }
+local AutoCmd = { mt = {} }
+
+local __builtin_support = vim.fn.has('nvim-0.7') == 1
+
+-- Use the recent builtin APIs provided by neovim itself
+local function builtin(group, autos)
+  vim.api.nvim_create_augroup(group, {})
+
+  for _, auto in ipairs(autos) do
+    local opts = auto.opts or {}
+    opts.group = group
+    opts.pattern = auto.pattern
+
+    if type(auto.command) == "string" then
+      opts.command = auto.command
+    elseif type(auto.command) == "function" then
+      opts.callback = auto.command
+    end
+
+    vim.api.nvim_create_autocmd(auto.event, opts)
+  end
+end
+
+-- Use an old library to make the autos
+-- Note that relies on the local package manager to ensure this plugin is available
+local function polyfill(group, autos)
+  local poly = require 'autocmd-lua'
+  local autocmds = {}
+
+  for _, auto in ipairs(autos) do
+    local events = auto.event
+
+    if type(auto.event) == "string" then
+      events = { auto.event }
+    end
+
+    for _, e in ipairs(events) do
+      table.insert(autocmds, { event = e, pattern = auto.pattern, cmd = auto.command })
+    end
+  end
+
+  poly.augroup {
+    group = group,
+    autocmds = autocmds,
+  }
+end
+
+local autocmd = __builtin_support and builtin or polyfill
+
+function M.new()
+  local m = {}
+  setmetatable(m, M.mt)
+
+  return m
+end
+
+function M.mt.__index(_, group)
+  if Groups[group] ~= nil then
+    return Groups[group]
+  else
+    -- Create a group object that uses the autocmd function on being called.
+    -- This object should take the list of objects provided to it, insert
+    -- them into it's local storage and then execute autocmd on them
+    return Group.new(group)
+  end
+end
+
+-- Spawn a new Group with the given name
+function Group.new(name)
+  local g = { __name = name, __autos = {} }
+  setmetatable(g, Group.mt)
+  Groups[name] = g
+
+  return g
+end
+
+-- Insert a new auto command object spec into the provided Group's list
+function Group.insert(self, cmd)
+  if not cmd.disable then
+    table.insert(self.__autos, {
+      command = table.remove(cmd, 3),
+      pattern = table.remove(cmd, 2),
+      event = table.remove(cmd, 1),
+      opts = cmd
+    })
+  end
+end
+
+-- Spawn a new AutoCmd with the given event name, currying the parent group's name
+function Group.mt.__index(self, event)
+  return AutoCmd.new(self, event)
+end
+
+-- Allows module users to pass a Group a list of auto command parameters
+function Group.mt.__call(self, command_like)
+  if type(command_like) == "function" then
+    command_like(self)
+  elseif type(command_like) == "table" then
+    for _, auto in ipairs(command_like) do
+      Group.insert(self, auto)
+    end
+  end
+
+  autocmd(self.__name, self.__autos)
+end
+
+-- Create a new dummy object that stores its group and event
+-- Used to allow for currying of autocmd parameters
+function AutoCmd.new(group, event)
+  local a = { __group = group, __event = event }
+  setmetatable(a, AutoCmd.mt)
+
+  return a
+end
+
+-- Add the given partial arg list passed to this AutoCmd to the correct group
+function AutoCmd.mt.__call(self, args)
+  table.insert(args, 1, self.__event)
+  Group.insert(self.__group, args)
+end
+
+return M.new()

--- a/nvim/lua/psoxizsh/init.lua
+++ b/nvim/lua/psoxizsh/init.lua
@@ -65,6 +65,9 @@ local function psoxizsh_early_config()
   -- Use existing buffers
   o.switchbuf = { "useopen", "usetab" }
 
+  -- Set global statusline (0.7+ only)
+  if fn.has('nvim-0.7') == 1 then o.laststatus = 3 end
+
   -- Local pre plugin configuration
   util.try_mreload('pre')
 end

--- a/nvim/lua/psoxizsh/init.lua
+++ b/nvim/lua/psoxizsh/init.lua
@@ -1,0 +1,193 @@
+local o, g, fn, cmd = vim.opt, vim.g, vim.fn, vim.cmd
+local au, util = require 'psoxizsh.autocmd', require 'psoxizsh.util'
+
+local function psoxizsh_early_config()
+  -- Local early configuration
+  util.try_mreload('early')
+
+  -- Set global color scheme var
+  if not g.my_color_scheme then
+    g.my_color_scheme = 'one'
+  end
+
+  -- Hide buffers don't close them
+  o.hidden = true
+
+  -- Sane pane opening
+  o.splitbelow = true
+  o.splitright = true
+
+  -- File indent opts
+  o.encoding = "utf-8"
+
+  o.shiftwidth = 2
+  o.tabstop = 8
+  o.softtabstop = 2
+  o.expandtab = true
+
+  o.list = true
+  o.listchars:append {
+    trail     = '\u{02FD}',
+    extends   = '\u{22B3}',
+    precedes  = '\u{22B2}',
+    nbsp      = '\u{02EC}',
+    conceal   = '\u{2219}',
+    tab       = '\u{2559}\u{254C}\u{2556}',
+  }
+
+  o.ignorecase = true
+  o.infercase = true
+
+  cmd 'filetype plugin indent on'
+
+  -- Set completion messages off
+  o.shortmess:append { c = true }
+
+  -- Preview window + menu for autocompletions
+  o.completeopt:append {
+    'preview',
+    'menuone',
+    'longest',
+  }
+
+  -- Lower update time (Default 4000)
+  o.updatetime = 300
+
+  -- Numbered lines
+  o.number = true
+  o.relativenumber = true
+
+  o.signcolumn = 'yes:1'
+
+  -- Disable '--INSERT--' and friends
+  o.showmode = false
+
+  -- Use existing buffers
+  o.switchbuf = { "useopen", "usetab" }
+
+  -- Local pre plugin configuration
+  util.try_mreload('pre')
+end
+
+-- Load plugins
+
+local function psoxizsh_post_config(plugs)
+  local vimp = require 'vimp'
+  -- Local post plugin configuration
+  util.try_mreload('post')
+
+  -- Setup file backups
+  cmd ':silent !mkdir -p ~/.vimbackup'
+  o.backupdir = fn.expand('~') .. '/.vimbackup'
+  o.directory = fn.expand('~') .. '/.vimbackup'
+
+  o.hlsearch = true
+
+  -- ripgrep settings
+  g.rg_highlight = 'true'
+  g.rg_derive_root = 'true'
+
+  -- Other
+  g.rainbow_active = 1
+
+  au.PsoxFileAutos {
+    { 'FileType', 'yaml', 'setlocal indentkeys-=<:> ts=8 sts=2 sw=2 expandtab' },
+    { 'FileType', 'go',   'setlocal ts=8 sts=4 sw=4 noexpandtab' },
+    { 'FileType', 'quickfix,netrw', 'setlocal nobuflisted' },
+    { 'FileType', 'netrw', function() require('vimp').nmap({'buffer', 'silent'}, '<ESC>', ':call CloseNetrw()<CR>') end },
+  }
+
+  cmd([[
+  function! CloseNetrw() abort
+    for bufn in range(1, bufnr('$'))
+      if bufexists(bufn) && getbufvar(bufn, '&filetype') ==# 'netrw'
+        silent! execute 'bwipeout ' . bufn
+        if getline(2) =~# '^" Netrw '
+          silent! bwipeout
+        endif
+        return
+      endif
+    endfor
+  endfunction
+  ]])
+
+  if plugs:has('fzf') then
+    if fn.executable('rg') == 1 then
+      vimp.nnoremap('<A-g>', ':Rg ')
+      vimp.nnoremap('<leader><A-g>', ':Rg! ')
+      vimp.nnoremap({'silent'}, '<A-S-g>', ':Rg<CR>')
+      vimp.nnoremap({'silent'}, '<leader><A-S-g>', ':Rg!<CR>')
+    end
+
+    vimp.nnoremap('<A-f>', ':Files ')
+    vimp.nnoremap('<leader><A-f>', ':Files! ')
+    vimp.nnoremap({'silent'}, '<A-S-f>', ':Files<CR>')
+    vimp.nnoremap({'silent'}, '<leader><A-S-f>', ':Files!<CR>')
+
+    vimp.nnoremap('<A-b>', ':Buffers ')
+    vimp.nnoremap('<leader><A-b>', ':Buffers! ')
+    vimp.nnoremap({'silent'}, '<A-S-b>', ':Buffers<CR>')
+    vimp.nnoremap({'silent'}, '<leader><A-S-b>', ':Buffers!<CR>')
+  end
+
+  -- Workaround for writing readonly files
+  vimp.cnoremap({'silent'}, 'w!!', 'w !sudo tee % >/dev/null')
+
+  -- Open any known user configuration paths for editing
+  vimp.nnoremap({'silent'}, '<leader>ve', function()
+    local rtp = vim.fn.join(o.runtimepath:get(), ',')
+    local files = {
+      early = vim.fn.globpath(rtp, '/lua/early.lua', 0, 1)[1] or nil,
+      pre   = vim.fn.globpath(rtp, '/lua/pre.lua', 0, 1)[1] or nil,
+      post  = vim.fn.globpath(rtp, '/lua/post.lua', 0, 1)[1] or nil,
+      late  = vim.fn.globpath(rtp, '/lua/late.lua', 0, 1)[1] or nil,
+      my    = os.getenv("MYVIMRC") or nil,
+    }
+
+    for _, file in pairs(files) do
+      if vim.fn.filereadable(file) == 1 then
+        cmd('edit ' .. file)
+      end
+    end
+  end)
+
+  -- Toggles all gutter items
+  vimp.nnoremap({'silent'}, '<leader>N', function()
+    if o.number:get() then
+      o.number = false
+      o.relativenumber = false
+      o.signcolumn = 'no'
+    else
+      o.number = true
+      o.relativenumber = true
+      o.signcolumn = 'yes:1'
+    end
+  end)
+
+  -- Reload configuration
+  vimp.nnoremap('<leader>vs', function() vimp.unmap_all() plugs:reload() end)
+
+  o.background = 'dark'
+  o.termguicolors = true
+  g.one_allow_italics = 1
+  cmd('highlight Comment term=italic cterm=italic gui=italic')
+end
+
+local function psoxizsh_late_config(_)
+  -- Local late configuration
+  util.try_mreload('late')
+
+  -- Rest of config below is specifically not user override-able
+  o.exrc = true
+  o.secure = true
+  o.modeline = true
+  o.modelines = 7
+end
+
+local hooks = {
+  early = { 'PsoxConfigEarly', psoxizsh_early_config },
+  post  = { 'PsoxConfigPost',  psoxizsh_post_config },
+  late  = { 'PsoxConfigLate',  psoxizsh_late_config },
+}
+
+return require('psoxizsh.plugins') { hooks = hooks }

--- a/nvim/lua/psoxizsh/plugins/bootstrap.lua
+++ b/nvim/lua/psoxizsh/plugins/bootstrap.lua
@@ -1,0 +1,24 @@
+local fn = vim.fn
+local install_path = fn.stdpath('data')..'/site/pack/packer/opt/packer.nvim'
+local repo_url = 'https://github.com/wbthomason/packer.nvim'
+local strapped = nil
+
+-- Bootstraps our package manager, ensuring it is present on the local system
+local function bootstrap()
+  local should_install = fn.empty(fn.glob(install_path)) > 0
+
+  if should_install then
+    fn.system({'git', 'clone', '--depth', '1', repo_url, install_path})
+  end
+
+  return should_install
+end
+
+if not strapped then
+  strapped = bootstrap()
+end
+
+return function()
+  return strapped
+end
+

--- a/nvim/lua/psoxizsh/plugins/config/bufferline.lua
+++ b/nvim/lua/psoxizsh/plugins/config/bufferline.lua
@@ -1,0 +1,23 @@
+return function()
+  local bl, vimp, util = require 'bufferline', require 'vimp', require 'psoxizsh.util'
+
+  local defaults = {
+    always_show_bufferline = true,
+    numbers = "none",
+    diagnostics = 'coc',
+    offsets = {{
+      filetype = 'neo-tree',
+      text = 'File Explorer',
+      text_align = 'center'
+    }},
+    show_buffer_close_icons = false,
+    separator_style = { '\u{E0B0}', '\u{E0B1}' },
+    sort_by = 'relative_directory',
+  }
+
+  bl.setup { options = util.mconfig('config.bufferline', defaults) }
+
+  vimp.nnoremap({'silent'}, '<TAB>',          ':BufferLineCycleNext<CR>')
+  vimp.nnoremap({'silent'}, '<S-TAB>',        ':BufferLineCyclePrev<CR>')
+  vimp.nnoremap({'silent'}, '<leader><TAB>',  ':BufferLinePick<CR>')
+end

--- a/nvim/lua/psoxizsh/plugins/config/coc.lua
+++ b/nvim/lua/psoxizsh/plugins/config/coc.lua
@@ -1,0 +1,103 @@
+return function()
+  local fn, o, g = vim.fn, vim.opt, vim.g
+  local vimp, au = require 'vimp', require 'psoxizsh.autocmd'
+
+  if fn.executable('node') == 0 then return end
+
+  local t = function(s)
+    return vim.api.nvim_replace_termcodes(s, true, true, true)
+  end
+  local pumvisible = function()
+    return fn.pumvisible() == 1
+  end
+
+  g['coc_global_extensions'] = {
+    'coc-yank',
+    'coc-spell-checker',
+    'coc-vimlsp',
+    'coc-rust-analyzer',
+    'coc-json',
+    'coc-markdownlint',
+    'coc-yaml'
+  }
+
+  -- Do action on current word
+  vimp.nmap({'silent'}, '<leader>.', '<Plug>(coc-codeaction-selected)w')
+
+  -- Do action on a selection
+  vimp.nmap({'silent'}, '<leader>/', '<Plug>(coc-codeaction-selected)')
+  vimp.xmap({'silent'}, '<leader>/', '<Plug>(coc-codeaction-selected)')
+
+  -- Rename symbol
+  vimp.nmap({'silent'}, '<leader>rn', '<Plug>(coc-rename)')
+  -- Goto definition / references
+  vimp.nmap({'silent'}, '<leader>gd', '<Plug>(coc-definition)')
+  vimp.nmap({'silent'}, '<leader>gr', '<Plug>(coc-references)')
+
+  -- Basically, we're checking to see if the column behind the current
+  -- either doesn't exist or is whitespace
+  local ck_backspace = function()
+    local col = fn.col('.') - 1
+
+    return
+      col == 0
+        and true
+      or fn.getline('.'):sub(col, col):match('%s')
+        and true
+      or false
+  end
+
+  vimp.inoremap({'silent', 'expr'}, '<TAB>', function()
+    return
+      pumvisible()
+        and t'<C-n>'
+      or ck_backspace()
+        and t'<TAB>'
+      or fn['coc#refresh']()
+  end)
+  vimp.inoremap({'expr'}, '<S-TAB>', function()
+    return pumvisible() and t'<C-p>' or t'<C-h>'
+  end)
+
+  -- Use <c-space> to confirm completion, `<C-g>u` means break undo chain at current
+  -- position. Coc only does snippet and additional edit on confirm.
+  -- <c-space> could be remapped by other vim plugin, try `:verbose imap <CR>`.
+  vimp.inoremap({'expr'}, '<C-Space>', function()
+    local info =
+      fn.exists('*complete_info') == 1
+        and fn.complete_info().selected ~= -1
+      or pumvisible()
+
+    return info and t'<C-y>' or t'<C-g>u<CR>'
+  end)
+
+  -- Use `[g` and `]g` to navigate diagnostics
+  vimp.nmap({'silent'}, '[g', '<Plug>(coc-diagnostic-prev)')
+  vimp.nmap({'silent'}, ']g', '<Plug>(coc-diagnostic-next)')
+
+  if fn.has('nvim-0.4') then
+    -- Remap PageUp and PageDown for scroll float windows/popups.
+    vimp.nnoremap({'silent', 'nowait', 'expr'}, '<PageDown>', [[coc#float#has_scroll() ? coc#float#scroll(1) : "\<PageDown>"]])
+    vimp.nnoremap({'silent', 'nowait', 'expr'}, '<PageUp>', [[coc#float#has_scroll() ? coc#float#scroll(0) : "\<PageUp>"]])
+  end
+
+  -- Use K to show documentation in preview window.
+  local show_documentation = function()
+    if vim.tbl_contains({'vim', 'help'}, o.filetype:get()) then
+      vim.cmd('help ' .. fn.expand(t'<cword>'))
+    elseif vim.fn['coc#rpc#ready']() == 1 then
+      vim.fn.CocActionAsync('doHover')
+    else
+      vim.cmd('!' .. o.keywordprg:get() .. ' ' .. fn.expand(t'<cword>'))
+    end
+  end
+  vimp.nnoremap({'silent'}, 'K', show_documentation)
+
+  -- Open yank list
+  vimp.nnoremap({'silent'}, '<C-Y>', t':<C-u>CocList -A --normal yank<CR>')
+
+  au.PsoxCocAutos {
+    { 'CursorHold', '*', function() fn.CocActionAsync('highlight') end },
+    { 'User', 'CocJumpPlaceholder', function() fn.CocActionAsync('showSignatureHelp') end },
+  }
+end

--- a/nvim/lua/psoxizsh/plugins/config/fzf.lua
+++ b/nvim/lua/psoxizsh/plugins/config/fzf.lua
@@ -1,0 +1,35 @@
+return function()
+  local fn, o, api = vim.fn, vim.o, vim.api
+
+  if fn.executable('rg') == 1 then
+    -- Override the default grep implementation in vim
+    o.grepprg = 'rg --vimgrep --smart-case --follow'
+
+    if fn.has('nvim-0.7') == 1 then
+      -- Only search file contents, not file name
+      -- We can use the stock :Files for that
+      local rg_func = function(opts)
+        return fn['fzf#vim#grep'](
+          "rg --column --line-number --no-heading --color=always --smart-case " .. fn.shellescape(opts.args),
+          true,
+          fn['fzf#vim#with_preview']({options = '--delimiter : --nth 4..'}),
+          opts.bang
+        )
+      end
+      api.nvim_create_user_command('Rg', rg_func, { nargs = '*', bang = true })
+
+      -- If the user hasn't set a default FZF command, and has ripgrep installed,
+      -- use it over find, otherwise defer to the user's preferred command
+      if fn.empty(os.getenv('FZF_DEFAULT_COMMAND')) == 1 then
+        local files_func = function(opts)
+          return fn['fzf#vim#files'](
+            opts.args,
+            fn['fzf#vim#with_preview']({source = 'rg --files --hidden --glob "!**/.git/**" '}),
+            opts.bang
+          )
+        end
+        api.nvim_create_user_command('Files', files_func, { nargs = '?', bang = true, complete = 'dir' })
+      end
+    end
+  end
+end

--- a/nvim/lua/psoxizsh/plugins/config/gitsigns.lua
+++ b/nvim/lua/psoxizsh/plugins/config/gitsigns.lua
@@ -1,0 +1,12 @@
+return function()
+  local gitsigns, util = require 'gitsigns', require 'psoxizsh.util'
+
+  local defaults = {
+    sign_priority = 100,
+    current_line_blame_formatter_opts = {
+      relative_time = false
+    },
+  }
+
+  gitsigns.setup(util.mconfig('config.gitsigns', defaults))
+end

--- a/nvim/lua/psoxizsh/plugins/config/lualine.lua
+++ b/nvim/lua/psoxizsh/plugins/config/lualine.lua
@@ -1,0 +1,65 @@
+return function()
+  local ll, util, nwd = require 'lualine', require 'psoxizsh.util', require("nvim-web-devicons")
+
+  local file_color = function()
+    local _, color = nwd.get_icon_colors_by_filetype(vim.bo.filetype)
+
+    return { fg = color }
+  end
+  local diff_source = function()
+    -- May be nil if gitsigns hasn't populated yet
+    local gs = vim.b.gitsigns_status_dict or {}
+
+    return {
+      added = gs.added,
+      modified = gs.changed,
+      removed = gs.removed,
+    }
+  end
+
+  local filename = {
+    'filename',
+    icon = 'ƒ',
+    symbols = { modified = '|', readonly = '|', unnamed = '〜' },
+    color = file_color,
+  }
+  local branch = { 'branch', icon = '', color = { gui = 'bold,italic' } }
+  local diagnostics = { 'diagnostics', sources = { 'coc' }, update_in_insert = true }
+  local diff = { 'diff', source = diff_source }
+
+  local defaults = {
+    options = {
+      theme = 'auto',
+      icons_enabled = true,
+      component_separators = { left = '', right = ''},
+      section_separators = { left = '', right = ''},
+      disabled_filetypes = {},
+      always_divide_middle = true,
+      globalstatus = true,
+      refresh = {
+        statusline = 1000,
+        tabline = 1000,
+        winbar = 1000,
+      }
+    },
+    sections = {
+      lualine_a = { 'mode' },
+      lualine_b = { branch, diff, diagnostics },
+      lualine_c = { filename },
+      lualine_x = {'filetype', 'encoding', 'fileformat'},
+      lualine_y = {'progress'},
+      lualine_z = {'location'}
+    },
+    inactive_sections = {
+      lualine_a = {},
+      lualine_b = {},
+      lualine_c = { filename },
+      lualine_x = { 'location' },
+      lualine_y = {},
+      lualine_z = {}
+    },
+    extensions = { 'fugitive', 'quickfix', 'man', 'fzf', 'neo-tree' }
+  }
+
+  ll.setup(util.mconfig('config.lualine', defaults))
+end

--- a/nvim/lua/psoxizsh/plugins/config/neomake.lua
+++ b/nvim/lua/psoxizsh/plugins/config/neomake.lua
@@ -1,0 +1,14 @@
+return function()
+  local g, fn = vim.g, vim.fn
+
+  -- Don't move cursor into qf/loc on open
+  g.neomake_open_list = 2
+  -- Allow multiple makers to resolve
+  g.neomake_serialize = 1
+  g.neomake_serialize_abort_on_error = 1
+
+  -- Let Neomake control window size
+  g.qf_auto_resize = 0
+
+  fn['neomake#configure#automake']('rw', 800)
+end

--- a/nvim/lua/psoxizsh/plugins/config/neotree.lua
+++ b/nvim/lua/psoxizsh/plugins/config/neotree.lua
@@ -1,0 +1,162 @@
+return function()
+  local g, fn = vim.g, vim.fn
+  local neotree, util, vimp = require 'neo-tree', require 'psoxizsh.util', require 'vimp'
+
+  local defaults = {
+    close_if_last_window = true,
+    enable_git_status = true,
+    default_component_configs = {
+      container = {
+        enable_character_fade = true
+      },
+      indent = {
+        indent_size = 2,
+        padding = 1, -- extra padding on left hand side
+        -- indent guides
+        with_markers = true,
+        indent_marker = "│",
+        last_indent_marker = "└",
+        highlight = "NeoTreeIndentMarker",
+        -- expander config, needed for nesting files
+        with_expanders = nil, -- if nil and file nesting is enabled, will enable expanders
+        expander_collapsed = "",
+        expander_expanded = "",
+        expander_highlight = "NeoTreeExpander",
+      },
+      icon = {
+        folder_closed = "",
+        folder_open = "",
+        folder_empty = "ﰊ",
+        -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
+        -- then these will never be used.
+        default = "*",
+        highlight = "NeoTreeFileIcon"
+      },
+      modified = {
+        symbol = "[+]",
+        highlight = "NeoTreeModified",
+      },
+      name = {
+        trailing_slash = false,
+        use_git_status_colors = true,
+        highlight = "NeoTreeFileName",
+      },
+      git_status = {
+        symbols = {
+          -- Change type
+          added     = "✚", -- or "✚", but this is redundant info if you use git_status_colors on the name
+          modified  = "~", -- or "", but this is redundant info if you use git_status_colors on the name
+          deleted   = "✖",-- this can only be used in the git_status source
+          renamed   = "",-- this can only be used in the git_status source
+          -- Status type
+          untracked = "",
+          ignored   = "",
+          unstaged  = "",
+          staged    = "",
+          conflict  = "",
+        },
+      },
+    },
+    window = {
+      position = "left",
+      width = 40,
+      mapping_options = {
+        noremap = true,
+        nowait = true,
+      },
+      mappings = {
+        ["?"]       = "show_help",
+        ["q"]       = "close_window",
+        ["R"]       = "refresh",
+        ["<space>"] = {  "toggle_node", nowait = false },
+        ["<cr>"]    = "open",
+        ["S"]       = "open_split",
+        ["s"]       = "open_vsplit",
+        ["C"]       = "close_node",
+        ["z"]       = "close_all_nodes",
+        ["Z"]       = "expand_all_nodes",
+        ["X"]       = "delete",
+        ["r"]       = "rename",
+        ["a"]       = { "add", config = { show_path = "relative" } },
+        ["A"]       = { "add_directory", config = { show_path = "relative" } },
+        ["c"]       = { "copy", config = { show_path = "relative" } },
+        ["m"]       = { "move", config = { show_path = "relative" } },
+        ["y"]       = "copy_to_clipboard",
+        ["p"]       = "paste_from_clipboard",
+      },
+    },
+    filesystem = {
+      filtered_items = {
+        visible = false, -- when true, they will just be displayed differently than normal items
+        hide_dotfiles = true,
+        hide_gitignored = true,
+        hide_hidden = true, -- only works on Windows for hidden files/directories
+        hide_by_name = { --[[ Example: 'node_modules' ]] },
+        hide_by_pattern = { --[[ Example '*.meta' ]] },
+        never_show = { --[[ remains hidden even if visible is toggled to true ]] },
+      },
+      follow_current_file = true, -- This will find and focus the file in the active buffer every
+                                   -- time the current file is changed while the tree is open.
+      group_empty_dirs = false, -- when true, empty folders will be grouped together
+      hijack_netrw_behavior = "open_default",  -- netrw disabled, opening a directory opens neo-tree
+                                               -- in whatever position is specified in window.position
+                            -- "open_current", -- netrw disabled, opening a directory opens within the
+                                               -- window like netrw would, regardless of window.position
+                            -- "disabled",     -- netrw left alone, neo-tree does not handle opening dirs
+      use_libuv_file_watcher = true,  -- This will use the OS level file watchers to detect changes
+                                      -- instead of relying on nvim autocmd events.
+      window = {
+        mappings = {
+          ["<bs>"]  = "navigate_up",
+          ["."]     = "set_root",
+          ["H"]     = "toggle_hidden",
+          ["/"]     = "fuzzy_finder",
+          ["D"]     = "fuzzy_finder_directory",
+          ["f"]     = "filter_on_submit",
+          ["<c-x>"] = "clear_filter",
+          ["[g"]    = "prev_git_modified",
+          ["]g"]    = "next_git_modified",
+        },
+      },
+    },
+    buffers = {
+      follow_current_file = true, -- This will find and focus the file in the active buffer every
+                                  -- time the current file is changed while the tree is open.
+      group_empty_dirs = true,    -- when true, empty folders will be grouped together
+      show_unloaded = true,
+      window = {
+        mappings = {
+          ["X"]     = "buffer_delete",
+          ["<bs>"]  = "navigate_up",
+          ["."]     = "set_root",
+        },
+      },
+    },
+    git_status = {
+      window = {
+        position = "float",
+        mappings = {
+          ["A"]  = "git_add_all",
+          ["gu"] = "git_unstage_file",
+          ["ga"] = "git_add_file",
+          ["gr"] = "git_revert_file",
+          ["gc"] = "git_commit",
+          ["gp"] = "git_push",
+          ["gg"] = "git_commit_and_push",
+        },
+      },
+    },
+  }
+
+  g['neo_tree_remove_legacy_commands'] = 1
+  fn.sign_define("DiagnosticSignError", {text = " ", texthl = "DiagnosticSignError"})
+  fn.sign_define("DiagnosticSignWarn", {text = " ", texthl = "DiagnosticSignWarn"})
+  fn.sign_define("DiagnosticSignInfo", {text = " ", texthl = "DiagnosticSignInfo"})
+  fn.sign_define("DiagnosticSignHint", {text = "", texthl = "DiagnosticSignHint"})
+
+  vimp.nnoremap({'silent'}, '<F2>', ':Neotree toggle reveal position=left<CR>')
+  vimp.nnoremap({'silent'}, '<leader>gs', ':Neotree float git_status<CR>')
+  vimp.nnoremap({'silent'}, '<leader><S-TAB>', ':Neotree toggle reveal float source=buffers<CR>')
+
+  neotree.setup(util.mconfig('config.neotree', defaults))
+end

--- a/nvim/lua/psoxizsh/plugins/config/pear-tree.lua
+++ b/nvim/lua/psoxizsh/plugins/config/pear-tree.lua
@@ -1,0 +1,8 @@
+return function()
+  local g = vim.g
+
+  -- Balance pairs when on open, close and delete
+  g.pear_tree_smart_openers = 1
+  g.pear_tree_smart_closers = 1
+  g.pear_tree_smart_backspace = 1
+end

--- a/nvim/lua/psoxizsh/plugins/config/vim-qf.lua
+++ b/nvim/lua/psoxizsh/plugins/config/vim-qf.lua
@@ -1,0 +1,11 @@
+
+return function()
+  local g = vim.g
+
+  -- Don't force qf/loc windows to bottom
+  g.qf_window_bottom = 0
+  g.qf_loclist_window_bottom = 0
+
+  -- Let Neomake control window size
+  g.qf_auto_resize = 0
+end

--- a/nvim/lua/psoxizsh/plugins/config/vim-tmux-navigator.lua
+++ b/nvim/lua/psoxizsh/plugins/config/vim-tmux-navigator.lua
@@ -1,0 +1,11 @@
+return function()
+ local g, vimp = vim.g, require 'vimp'
+
+ g['tmux_navigator_no_mappings'] = 1
+ g['tmux_navigator_disable_when_zoomed'] = 1
+
+ vimp.nnoremap({'override', 'silent'}, '<C-h>', ':TmuxNavigateLeft<CR>')
+ vimp.nnoremap({'override', 'silent'}, '<C-j>', ':TmuxNavigateDown<CR>')
+ vimp.nnoremap({'override', 'silent'}, '<C-k>', ':TmuxNavigateUp<CR>')
+ vimp.nnoremap({'override', 'silent'}, '<C-l>', ':TmuxNavigateRight<CR>')
+end

--- a/nvim/lua/psoxizsh/plugins/init.lua
+++ b/nvim/lua/psoxizsh/plugins/init.lua
@@ -1,0 +1,217 @@
+local cmd, bootstrap, util = vim.cmd, require 'psoxizsh.plugins.bootstrap', require 'psoxizsh.util'
+local cb_table = {}
+local packer = nil
+
+-- Plugins provides a hook based wrapper around packer.nvim, allowing
+-- callers to register hooks at specific lifecycle events such as pre
+-- and post plugin load.
+--
+-- A new, uninitialized one is provided upon requiring this module,
+-- See :setup/1 and :init/0 for more on configuring and initializing
+-- this object
+local Plugins = { mt = {} }
+
+-- Creates a new, uninitialized Plugins
+--
+-- You must call :init/0 (and likely :setup/1) before using this
+-- object, though you can directly invoke the Plugins object as
+-- you would :setup/1 as a convenience
+function Plugins.new()
+  local m = {
+    _list = {},
+    _hooks = {},
+  }
+  setmetatable(m, Plugins.mt)
+
+  return m
+end
+
+-- Configures this Plugins, with the provided opts
+--
+-- You can provide a tables of hooks by name or { name, callback }
+-- tuples.
+--
+-- In the former case, Plugins will create User <name> autocmds
+-- when the lifecycle stage is hit, which you can register arbitrary
+-- code to be invoked on.
+--
+-- In the latter, the provided callback fn will be invoked at the
+-- lifecycle stage, with 'post' and 'late' hooks being provided the
+-- current Plugins object as the first argument
+--
+-- @opts = {
+--   hooks = {
+--     early = name | { name, callback/0 }
+--     pre   = name | { name, callback/0 }
+--     post  = name | { name, callback/1 }
+--     late  = name | { name, callback/1 }
+--   }
+-- }
+function Plugins.setup(self, opts)
+  opts = opts or {}
+  local hooks = opts.hooks or {}
+
+  self._hooks = vim.tbl_map(function(hk)
+    local t = type(hk)
+    if t == 'string' then return hk end
+    if t == 'table' then return hk[1] end
+  end, hooks)
+
+  local callbacks = vim.tbl_map(function(hk)
+    local t = type(hk[2])
+    if t == 'function' then return hk[2] end
+  end, hooks)
+
+  self:list_regen()
+  self:register_callbacks(callbacks)
+
+  return self
+end
+
+-- Invokes the plugin manager, and hooks any provided hooks as they become ready
+--
+-- Note, you shouldn't rerun this function, use :reload/0 instead if you want to
+-- reload an existing Plugins
+function Plugins.init(self)
+  self:do_hook 'early'
+
+  if packer == nil then
+    cmd [[packadd packer.nvim]]
+
+    packer = require 'packer'
+    packer.init {
+      max_jobs = 32
+    }
+  end
+
+  packer.reset()
+
+  self:do_hook 'pre'
+
+  for _, spec in ipairs(self:list()) do
+    packer.use(spec)
+  end
+
+  self:do_hook 'post'
+  self:do_hook 'late'
+
+  return self
+end
+
+-- Regenerate the plugin spec list, reloading the config if it has changed.
+--
+-- Note that this method *only* reloads the spec list, it does not reload
+-- plugins, see :reload/0 for that
+function Plugins.list_regen(self)
+  local plugs = util.mreload('psoxizsh.plugins.plug')
+  self._list = plugs(util.try_mconfig('plug'))
+
+  return self:list()
+end
+
+-- Return the current plugin list
+function Plugins.list(self)
+  return self._list
+end
+
+-- Get the plugin spec for the provided @id.
+--
+-- The plugin id will be either the last component of the name, or if redefined by 'as',
+-- whatever 'as' is.
+--
+-- Returns the spec if it exists, nil otherwise
+function Plugins.get(self, id)
+  local needle = function(p)
+    local plugid = p.as and p.as or p[1] and p[1]:match("^.+/(.+)$")
+
+    return plugid == id
+  end
+
+  return vim.tbl_filter(needle, self:list())[1]
+end
+
+-- Check if the plugin @id exists in the current spec table
+--
+-- Returns true if it does, nil otherwise
+function Plugins.has(self, id)
+  return self:get(id) and true or nil
+end
+
+-- Reload plugins, and rerun any registered hooks
+function Plugins.reload(self)
+  self:list_regen()
+  self:init()
+  packer.compile()
+end
+
+-- Request the active Plugins to run the provided lifecycle's hook
+--
+-- Note that this may not run immediately, depending on current lifecycle
+-- of underlying plugin manager
+--
+-- @name { 'early' | 'pre' | 'post' | 'late' }
+function Plugins.do_hook(self, name)
+  if name and name == 'post' or 'late' then
+    self:_post_hook(self._hooks[name])
+  else
+    self:_pre_hook(self._hooks[name])
+  end
+end
+
+-- Manually (re)register callbacks for any configured lifecycle hooks
+--
+-- Note that any hooks that were not registered in :setup/1 will be
+-- silently ignored.
+--
+-- You may consider re-initializing the active Plugins via :setup/1:init/0
+function Plugins.register_callbacks(self, callbacks)
+    _G._psoxizsh_plugins_cb = function(id) cb_table[id](self) end
+    cb_table = {}
+
+    cmd [[augroup PsoxConfigCallbacks]]
+    cmd [[autocmd!]]
+    for n, fn in pairs(callbacks) do
+      local id = self._hooks[n]
+      cb_table[id] = fn
+      cmd(string.format('autocmd User %s call v:lua._psoxizsh_plugins_cb("%s")', id, id))
+    end
+    cmd [[augroup END]]
+end
+
+function Plugins._pre_hook(self, hook)
+  self:_dispatch_autocmd(hook)
+end
+
+function Plugins._post_hook(self, hook)
+  if bootstrap() and hook then
+    cmd [[augroup PsoxConfigBootstrap]]
+    cmd [[autocmd!]]
+    cmd [[autocmd VimEnter * ++once PackerSync]]
+    cmd [[augroup END]]
+
+    cmd ('augroup PsoxConfigDeferHook_' .. hook)
+    cmd ('autocmd!')
+    cmd ('autocmd User PackerCompileDone doautocmd User ' .. hook)
+    cmd ('augroup END')
+  else
+    self:_dispatch_autocmd(hook)
+  end
+end
+
+function Plugins._dispatch_autocmd(_, hook)
+  if hook then cmd('doautocmd User ' .. hook) end
+end
+
+-- Setup a convenience method for setting up + initializing a Plugins object
+-- via directly calling the object with the opts that would normally be
+-- provided to :setup/1
+function Plugins.mt.__call(self, opts)
+    self:setup(opts):init()
+end
+
+-- Allow callers to access the underlying packer object
+function Plugins.mt.__index(_, key)
+  return Plugins[key] or packer[key]
+end
+
+return Plugins.new()

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -7,6 +7,9 @@ local plugins = {
       module_pattern = { 'packer', 'packer%..*' }
   },
 
+  -- Community patch for Vim
+  { 'tpope/vim-sensible' },
+
   -- Utils for wrapping vimscript in lua easier
   { 'svermeulen/vimpeccable',
       as = 'vimp'
@@ -16,6 +19,65 @@ local plugins = {
   { 'jakelinnzy/autocmd-lua',
       disable = vim.fn.has('nvim-0.7') == 1
   },
+
+  -- Text alignment
+  { 'junegunn/vim-easy-align' },
+  { 'tmsvg/pear-tree',
+      config = require 'psoxizsh.plugins.config.pear-tree'
+  },
+
+  -- Git integration
+  { 'tpope/vim-fugitive' },
+
+  -- Comment helpers
+  { 'scrooloose/nerdcommenter' },
+
+  -- Stat line integrations
+
+  -- Buffer mangement
+  { 'qpkorr/vim-bufkill' },
+  { 'romainl/vim-qf',
+      config = require 'psoxizsh.plugins.config.vim-qf'
+  },
+
+  -- IDE stuff + language highlighting
+  { 'neomake/neomake',
+      config = require 'psoxizsh.plugins.config.neomake'
+  },
+  { 'vim-perl/vim-perl',
+      ft = 'perl',
+      run = 'make clean carp dancer highlight-all-pragmas moose test-more try-tiny'
+  },
+  { 'rust-lang/rust.vim',
+      ft = 'rust'
+  },
+  { 'pearofducks/ansible-vim',
+      ft = {'yaml', 'yml'}
+  },
+  { 'kevinoid/vim-jsonc' },
+  { 'luochen1990/rainbow' },
+  { 'sheerun/vim-polyglot' },
+
+  -- Fuzzy search helpers
+  { 'junegunn/fzf',
+      cmd = 'FZF',
+      fn = { 'fzf#run', 'fzf#wrap' }
+  },
+  { 'junegunn/fzf.vim',
+      config = require 'psoxizsh.plugins.config.fzf'
+  },
+  { 'adelarsq/vim-matchit' },
+  { 'mox-mox/vim-localsearch' },
+
+  -- Color themes
+  { 'rakr/vim-one',
+      config = function() vim.cmd(string.format('colorscheme %s', vim.g.my_color_scheme or 'one')) end
+  },
+  { 'romainl/vim-cool' },
+
+  -- Other
+  { 'roxma/nvim-yarp' },
+  { 'roxma/vim-hug-neovim-rpc' },
 }
 
 local function concatArray(a, b)

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -29,6 +29,21 @@ local plugins = {
   -- Git integration
   { 'tpope/vim-fugitive' },
 
+  -- File browser
+  { 'nvim-neo-tree/neo-tree.nvim',
+      as = 'neo-tree',
+      branch = 'v2.x',
+      requires = {
+        'nvim-lua/plenary.nvim',
+        'kyazdani42/nvim-web-devicons',
+        'MunifTanjim/nui.nvim',
+      },
+      after = 'vimp',
+      cmd = { 'Neotree', 'NeoTree*' },
+      keys = { '<F2>', '<leader>gs', '<leader><S-TAB>' },
+      config = require 'psoxizsh.plugins.config.neotree'
+  },
+
   -- Comment helpers
   { 'scrooloose/nerdcommenter' },
 

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -109,6 +109,13 @@ local plugins = {
   },
   { 'romainl/vim-cool' },
 
+  -- Tmux integration for pane movement
+  { 'christoomey/vim-tmux-navigator',
+      keys = { '<C-h>', '<C-j>', '<C-k>', '<C-l>' },
+      cmd = { 'TmuxNavigateLeft', 'TmuxNavigateDown', 'TmuxNavigateUp', 'TmuxNavigateRight', 'TmuxNavigatePrevious' },
+      config = require 'psoxizsh.plugins.config.vim-tmux-navigator'
+  },
+
   -- Other
   { 'roxma/nvim-yarp' },
   { 'roxma/vim-hug-neovim-rpc' },

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -1,0 +1,18 @@
+
+local plugins = {
+}
+
+local function concatArray(a, b)
+  local result = {unpack(a)}
+  for i = 1,#b do
+    result[#a+i] = b[i]
+  end
+
+  return result
+end
+
+return function(extra)
+  extra = extra or {}
+
+  return concatArray(plugins, extra)
+end

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -7,6 +7,11 @@ local plugins = {
       module_pattern = { 'packer', 'packer%..*' }
   },
 
+  -- Utils for wrapping vimscript in lua easier
+  { 'svermeulen/vimpeccable',
+      as = 'vimp'
+  },
+
   -- Used for autocmds if we're not using a late enough version of neovim
   { 'jakelinnzy/autocmd-lua',
       disable = vim.fn.has('nvim-0.7') == 1

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -75,6 +75,11 @@ local plugins = {
   },
 
   -- IDE stuff + language highlighting
+  { 'neoclide/coc.nvim',
+      branch = 'release',
+      after = 'vimp',
+      config = require 'psoxizsh.plugins.config.coc'
+  },
   { 'neomake/neomake',
       config = require 'psoxizsh.plugins.config.neomake'
   },

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -1,5 +1,11 @@
 
 local plugins = {
+  -- Allow packer to manage itself
+  { 'wbthomason/packer.nvim',
+      opt = true,
+      cmd = 'Packer*',
+      module_pattern = { 'packer', 'packer%..*' }
+  },
 }
 
 local function concatArray(a, b)

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -48,6 +48,11 @@ local plugins = {
   { 'scrooloose/nerdcommenter' },
 
   -- Stat line integrations
+  { 'lewis6991/gitsigns.nvim',
+      tag = 'release',
+      requires = { 'nvim-lua/plenary.nvim' },
+      config = require 'psoxizsh.plugins.config.gitsigns'
+  },
 
   -- Buffer mangement
   { 'qpkorr/vim-bufkill' },

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -48,6 +48,13 @@ local plugins = {
   { 'scrooloose/nerdcommenter' },
 
   -- Stat line integrations
+  { 'akinsho/bufferline.nvim',
+      as = "bufferline",
+      tag = "v1.*",
+      requires = { 'kyazdani42/nvim-web-devicons' },
+      after = 'vimp',
+      config = require 'psoxizsh.plugins.config.bufferline'
+  },
   { 'lewis6991/gitsigns.nvim',
       tag = 'release',
       requires = { 'nvim-lua/plenary.nvim' },

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -48,6 +48,13 @@ local plugins = {
   { 'scrooloose/nerdcommenter' },
 
   -- Stat line integrations
+  { 'nvim-lualine/lualine.nvim',
+      requires = {
+        'kyazdani42/nvim-web-devicons',
+        'lewis6991/gitsigns.nvim'
+      },
+      config = require 'psoxizsh.plugins.config.lualine'
+  },
   { 'akinsho/bufferline.nvim',
       as = "bufferline",
       tag = "v1.*",

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -6,6 +6,11 @@ local plugins = {
       cmd = 'Packer*',
       module_pattern = { 'packer', 'packer%..*' }
   },
+
+  -- Used for autocmds if we're not using a late enough version of neovim
+  { 'jakelinnzy/autocmd-lua',
+      disable = vim.fn.has('nvim-0.7') == 1
+  },
 }
 
 local function concatArray(a, b)

--- a/nvim/lua/psoxizsh/util.lua
+++ b/nvim/lua/psoxizsh/util.lua
@@ -1,0 +1,68 @@
+
+local Util = {}
+
+-- Reload a given module, returning the result of loading it.
+function Util.mreload(module)
+  if package.loaded[module] then
+    package.loaded[module] = nil
+  end
+
+  return require(module)
+end
+
+-- Try reloading the given module, returning ok, module
+function Util.try_mreload(module)
+  return pcall(Util.mreload, module)
+end
+
+-- Try reloading the given config module, returning either
+-- its table or an empty one, if the module couldn't be loaded
+--
+-- The arguments can be:
+-- 1. module string --> table
+-- 2. module string --> fn() -> table
+-- 3. table
+-- 4. fn() --> table
+--
+-- It the latter cases, *configuration will not be reloaded*, this is
+-- primaraily meant for inline, static configuration
+function Util.try_mconfig(module)
+  if type(module) ~= "string" then
+    module = type(module) == "function" and module() or module
+    module = type(module) == "table" and module or {}
+
+    return module
+  end
+
+  local ok, config = Util.try_mreload(module)
+  config = type(config) == "function" and config() or config
+
+  return (ok and type(config) == "table") and config or {}
+end
+
+-- Retrieve the config table stored in the provided module,
+-- merged with default the config module, if one is provided
+--
+-- The arguments can be:
+-- 1. module string --> table
+-- 2. module string --> fn() -> table
+-- 3. table
+-- 4. fn() --> table
+--
+-- It the latter cases, *configuration will not be reloaded*, this is
+-- primaraily meant for inline, static configuration
+--
+-- Note: the config returned from the given module may optionally
+-- set 'no_defaults = true' to opt out of the merging
+function Util.mconfig(module, defaults)
+  module = Util.try_mconfig(module)
+  defaults = Util.try_mconfig(defaults)
+
+  if module.no_defaults then
+    return module
+  else
+    return vim.tbl_deep_extend('keep', module, defaults)
+  end
+end
+
+return Util

--- a/zshrc
+++ b/zshrc
@@ -117,12 +117,20 @@ plugins+=(
 if [[ "$OSTYPE" =~ "linux*" || "$OSTYPE" =~ "darwin*" || "$OSTYPE" == "cygwin" ]]
 then
   export VIMINIT='source $MYVIMRC'
-  export MYVIMRC=$PSOXIZSH/vimrc
   export VIMHOME=~/.vim
-  cmp $PSOXIZSH/vim/autoload/plug.vim $VIMHOME/autoload/plug.vim 2>/dev/null || (
-    mkdir -vp $VIMHOME/autoload/
-    cp -av $PSOXIZSH/vim/autoload/plug.vim $VIMHOME/autoload/plug.vim
-  )
+
+  # Feature flag lua based Neovim config, until this is tested
+  # (and we figure out how to detect if we're running nvim or vim)
+  if [[ -n ${PSOXIZSH_EXPERIMENTAL_NEOVIM_LUA} ]]
+  then
+    export MYVIMRC=$PSOXIZSH/init.lua
+  else
+    export MYVIMRC=$PSOXIZSH/vimrc
+    cmp $PSOXIZSH/vim/autoload/plug.vim $VIMHOME/autoload/plug.vim 2>/dev/null || (
+      mkdir -vp $VIMHOME/autoload/
+      cp -av $PSOXIZSH/vim/autoload/plug.vim $VIMHOME/autoload/plug.vim
+    )
+  fi
 fi
 
 if [[ -d ~/.ssh ]]


### PR DESCRIPTION
This PR adds support for a `lua` based configuration of Neovim.

It keeps feature parity with the `vimrc` variant, while improving on the previous init method in many significant ways:

1. Speed
2. Updated plugins
3. Better bootstrapping support
4. Much greater individual customization
5. Significantly easier configuration language (lua >> vimscript)

You may opt in to using it via setting `$PSOXIZSH_EXPERIMENTAL_NEOVIM_LUA` before sourcing `psoxizsh/zshrc` (e.g in your `~/.zshrc` file).

### Speed

The speed improvements come from several factors, including utilization of faster (parallel) nvim lua APIs, more loading of on demand config and using a "compiled" plugin set.

Generally, cold starts (bootstrapping the first run on a system) have slightly increased (~7s to ~9s), however hot starts and reloads have seen 2-5x improvements, depending on the filetype -- or rather, whether language server(s) are started -- with the gains increasing as the the amount of work required does.

### Plugins

Several plugins have been replaced with newer, Neovim based alternatives, almost universally bringing speed, customization and functionality.

Quoting 7294d94:

>- scrooloose/vim-statline
>  | 12 years old doesn't seem to have an effect
>- vim-airline/vim-airline-themes
>  vim-airline/vim-airline
>  | Throwing all sorts of errors when loaded by packer. Not sure what is
>    wrong, but I think it's just incompatible.
>- airblade/vim-gitgutter
>  | Nothing wrong with gitgutter, but it appears that a lot of the nvim
>    world uses (and more importantly, integrates with) gitsigns. It's also
>    a lot faster.
>- scrooloose/nerdtree
>  Xuyuanp/nerdtree-git-plugin
>  | Again, nothing really wrong with nerdtree, but there are better
>    options in neovim land (neo-tree.nvim)

Care was taken to keep the style and theme of the originals, and you can find the new comers in https://github.com/psox/psoxizsh/compare/a8ff036^^^^...a8ff036

Read the associated commits for more on each new plugin.

### Better bootstrapping

Under the old `vimrc`, bootstrapping (neo)vim would lead to a broken instance after the install had finished, requiring users to quit and reload. This has been fixed under the new config, and more generally configuration and be loaded in the background without freezing the editor; bringing improvements to reloading the config without restarting the editor, too.

### Individual customization

The per-system customization has also seen significant improvements, expanding on the old `{early,plug,post}.vimrc` system, by allowing users to extend or override configuration often on a per plugin basis, if possible.

Local config files can be added anywhere to the runtime path (but will typically be under `~/.config/nvim/lua`). A list of paths to config displayed below.

|Path|Plugin|Description|
| :-- |  :-- | :-- |
| `early.lua` | - | Before any other config is run |  
| `pre.lua` | - | Just *before* plugin configuration | 
| `post.lua` | - | Just *after* plugin configuration | 
| `late.lua` | - | After most configuration (several security settings always take presidence) | 
| `plug.lua` | - | Additional plugins to use |
| `config/neotree.lua` | https://github.com/nvim-neo-tree/neo-tree.nvim | NERDTree replacement for file viewer |
| `config/gitsigns.lua` | https://github.com/lewis6991/gitsigns.nvim | Git gutter (and general git integration)  |
| `config/bufferline.lua` | https://github.com/akinsho/bufferline.nvim | Buffer (and tab) bar |
| `config/lualine.lua` | https://github.com/nvim-lualine/lualine.nvim | Status line |


#### On defining local plugins

You can find the general idea and all available options here: [packer.nvim#specifying-plugins](https://github.com/wbthomason/packer.nvim#specifying-plugins), or take a look at the [default set](https://github.com/psox/psoxizsh/compare/feature/nvim/lua/base?expand=1#diff-a40382cc00e87a9d484a52c55ff212e9c93263c52f5175863bd970aad8f69729).

Your `plug.lua` should return one of `spec.table | fn/0 -> spec.table`, where `spec.table` is a list of packer.nvim plugins specs.

```lua
return {
	{ 'my/plugin' },
	{ 'another/plugin', after = 'plugin' },
}
```

_OR_

```lua
return function() {
	local plugs = { ... }
	
	-- conditional logic, etc
	return plugs
}
```

You can click though to each individual plugin's github page to get a list of its configuration options.

### Easier configuration language

```lua
-- Basically, we're checking to see if the column behind the current
-- either doesn't exist or is whitespace
local ck_backspace = function()
  local col = fn.col('.') - 1

  return
    col == 0
      and true
    or fn.getline('.'):sub(col, col):match('%s')
      and true
    or false
end
```

versus

```vim
function! s:check_back_space() abort
  let col = col('.') - 1
  return !col || getline('.')[col - 1]  =~# '\s'
endfunction
```

Enough said :)

___

This PR is large, but can be broken down either by commit (preferred) or into sections, laid out below as your choice.

I recommend `git log -p --histogram --reverse develop..` after pulling locally, but you may also use the UI, with the following sections:

1. [zshc changes](https://github.com/psox/psoxizsh/commit/b28994dfe0d3280eea487d237316b5b88949a501)
2. [utilities for module reloading](https://github.com/psox/psoxizsh/commit/30fe81160e9c80230422b8cda4ee780caa33d20b)
3. [utilities for autocmds](https://github.com/psox/psoxizsh/commit/730eaaf39a8b67af6d2e9d83ceaa5415051be349)
4. [plugin mangement](https://github.com/psox/psoxizsh/compare/59b3d8d^^...59b3d8d)
5. default plugins [#1](https://github.com/psox/psoxizsh/compare/d8c851a^...a0493e3) [#2](https://github.com/psox/psoxizsh/compare/89eaa8f^..212286c)
7. [global config](https://github.com/psox/psoxizsh/compare/c9ccdcd^...973632f)
8. [entrypoint](https://github.com/psox/psoxizsh/commit/e509f7a8a5b0c48ed17d285b555b92c4077b1684)