### PR TITLE
Wait for plugins to load before running user config

### DIFF
--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -10,6 +10,9 @@ local plugins = {
   -- Community patch for Vim
   { 'tpope/vim-sensible' },
 
+  -- Used in psoxizsh.* modules
+  { 'nvim-lua/plenary.nvim' },
+
   -- Utils for wrapping vimscript in lua easier
   { 'svermeulen/vimpeccable',
       as = 'vimp'


### PR DESCRIPTION
Quoting commit:

> This commit properly defers running of 'post' and 'late' user callbacks,
> by spawning a coroutine that waits until '_G.packer_plugins' exists.
> 
> This only happens after packer's compiled config is executed, thereby
> correctly delaying the callbacks.
> 
> Unfortunately, there's no easy way to do async in lua, so we _do_ take
> on a dependency to plenary.nvim, however this shouldn't affect bootstrap
> runs, as there we were already waiting for the 'PackerCompileDone'
> autocmd, which is only emitted after the compiled config is sourced.