### PR TITLE
Misc. fixes

### DIFF
--- a/nvim/lua/psoxizsh/autocmd.lua
+++ b/nvim/lua/psoxizsh/autocmd.lua
@@ -4,15 +4,13 @@ local Groups = {}
 local Group = { mt = {} }
 local AutoCmd = { mt = {} }
 
-local __builtin_support = vim.fn.has('nvim-0.7') == 1
-
 -- Use the recent builtin APIs provided by neovim itself
 local function builtin(group, autos)
-  vim.api.nvim_create_augroup(group, {})
+  local gid = vim.api.nvim_create_augroup(group, { clear = true })
 
   for _, auto in ipairs(autos) do
     local opts = auto.opts or {}
-    opts.group = group
+    opts.group = gid
     opts.pattern = auto.pattern
 
     if type(auto.command) == "string" then
@@ -25,31 +23,7 @@ local function builtin(group, autos)
   end
 end
 
--- Use an old library to make the autos
--- Note that relies on the local package manager to ensure this plugin is available
-local function polyfill(group, autos)
-  local poly = require 'autocmd-lua'
-  local autocmds = {}
-
-  for _, auto in ipairs(autos) do
-    local events = auto.event
-
-    if type(auto.event) == "string" then
-      events = { auto.event }
-    end
-
-    for _, e in ipairs(events) do
-      table.insert(autocmds, { event = e, pattern = auto.pattern, cmd = auto.command })
-    end
-  end
-
-  poly.augroup {
-    group = group,
-    autocmds = autocmds,
-  }
-end
-
-local autocmd = __builtin_support and builtin or polyfill
+local autocmd = builtin
 
 function M.new()
   local m = {}

--- a/nvim/lua/psoxizsh/init.lua
+++ b/nvim/lua/psoxizsh/init.lua
@@ -10,6 +10,10 @@ local function psoxizsh_early_config()
     g.my_color_scheme = 'one'
   end
 
+  -- Color settings
+  o.background = 'dark'
+  o.termguicolors = true
+
   -- Hide buffers don't close them
   o.hidden = true
 
@@ -172,8 +176,6 @@ local function psoxizsh_post_config(plugs)
   -- Reload configuration
   vimp.nnoremap('<leader>vs', function() vimp.unmap_all() plugs:reload() end)
 
-  o.background = 'dark'
-  o.termguicolors = true
   g.one_allow_italics = 1
   cmd('highlight Comment term=italic cterm=italic gui=italic')
 end

--- a/nvim/lua/psoxizsh/init.lua
+++ b/nvim/lua/psoxizsh/init.lua
@@ -79,6 +79,8 @@ local function psoxizsh_post_config(plugs)
   -- Local post plugin configuration
   util.try_mreload('post')
 
+  cmd('colorscheme ' .. vim.g.my_color_scheme)
+
   -- Setup file backups
   cmd ':silent !mkdir -p ~/.vimbackup'
   o.backupdir = fn.expand('~') .. '/.vimbackup'

--- a/nvim/lua/psoxizsh/plugins/config/lualine.lua
+++ b/nvim/lua/psoxizsh/plugins/config/lualine.lua
@@ -23,7 +23,7 @@ return function()
     symbols = { modified = '|', readonly = '|', unnamed = '〜' },
     color = file_color,
   }
-  local branch = { 'branch', icon = '', color = { gui = 'bold,italic' } }
+  local branch = { 'b:gitsigns_head', icon = '', color = { gui = 'bold' } }
   local diagnostics = { 'diagnostics', sources = { 'coc' }, update_in_insert = true }
   local diff = { 'diff', source = diff_source }
 
@@ -58,7 +58,7 @@ return function()
       lualine_y = {},
       lualine_z = {}
     },
-    extensions = { 'fugitive', 'quickfix', 'man', 'fzf', 'neo-tree' }
+    extensions = { 'fugitive', 'quickfix', 'man', 'fzf', 'neo-tree', 'toggleterm' }
   }
 
   ll.setup(util.mconfig('config.lualine', defaults))

--- a/nvim/lua/psoxizsh/plugins/config/neotree.lua
+++ b/nvim/lua/psoxizsh/plugins/config/neotree.lua
@@ -149,10 +149,6 @@ return function()
   }
 
   g['neo_tree_remove_legacy_commands'] = 1
-  fn.sign_define("DiagnosticSignError", {text = " ", texthl = "DiagnosticSignError"})
-  fn.sign_define("DiagnosticSignWarn", {text = " ", texthl = "DiagnosticSignWarn"})
-  fn.sign_define("DiagnosticSignInfo", {text = " ", texthl = "DiagnosticSignInfo"})
-  fn.sign_define("DiagnosticSignHint", {text = "", texthl = "DiagnosticSignHint"})
 
   vimp.nnoremap({'silent'}, '<F2>', ':Neotree toggle reveal position=left<CR>')
   vimp.nnoremap({'silent'}, '<leader>gs', ':Neotree float git_status<CR>')

--- a/nvim/lua/psoxizsh/plugins/config/vim-tmux-navigator.lua
+++ b/nvim/lua/psoxizsh/plugins/config/vim-tmux-navigator.lua
@@ -1,11 +1,11 @@
 return function()
- local g, vimp = vim.g, require 'vimp'
+  local g, vimp = vim.g, require 'vimp'
 
- g['tmux_navigator_no_mappings'] = 1
- g['tmux_navigator_disable_when_zoomed'] = 1
+  g['tmux_navigator_no_mappings'] = 1
+  g['tmux_navigator_disable_when_zoomed'] = 1
 
- vimp.nnoremap({'override', 'silent'}, '<C-h>', ':TmuxNavigateLeft<CR>')
- vimp.nnoremap({'override', 'silent'}, '<C-j>', ':TmuxNavigateDown<CR>')
- vimp.nnoremap({'override', 'silent'}, '<C-k>', ':TmuxNavigateUp<CR>')
- vimp.nnoremap({'override', 'silent'}, '<C-l>', ':TmuxNavigateRight<CR>')
+  vimp.nnoremap({'override', 'silent'}, '<C-h>', ':TmuxNavigateLeft<CR>')
+  vimp.nnoremap({'override', 'silent'}, '<C-j>', ':TmuxNavigateDown<CR>')
+  vimp.nnoremap({'override', 'silent'}, '<C-k>', ':TmuxNavigateUp<CR>')
+  vimp.nnoremap({'override', 'silent'}, '<C-l>', ':TmuxNavigateRight<CR>')
 end

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -18,11 +18,6 @@ local plugins = {
       as = 'vimp'
   },
 
-  -- Used for autocmds if we're not using a late enough version of neovim
-  { 'jakelinnzy/autocmd-lua',
-      disable = vim.fn.has('nvim-0.7') == 1
-  },
-
   -- Text alignment
   { 'junegunn/vim-easy-align' },
   { 'tmsvg/pear-tree',

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -54,8 +54,8 @@ local plugins = {
       config = require 'psoxizsh.plugins.config.lualine'
   },
   { 'akinsho/bufferline.nvim',
-      as = "bufferline",
-      tag = "v1.*",
+      as = 'bufferline',
+      tag = 'v1.*',
       requires = { 'kyazdani42/nvim-web-devicons' },
       after = 'vimp',
       config = require 'psoxizsh.plugins.config.bufferline'
@@ -66,7 +66,7 @@ local plugins = {
       config = require 'psoxizsh.plugins.config.gitsigns'
   },
 
-  -- Buffer mangement
+  -- Buffer management
   { 'qpkorr/vim-bufkill' },
   { 'romainl/vim-qf',
       config = require 'psoxizsh.plugins.config.vim-qf'

--- a/nvim/lua/psoxizsh/util/highlight.lua
+++ b/nvim/lua/psoxizsh/util/highlight.lua
@@ -1,0 +1,201 @@
+-- This module provides a highlight API that can be used in lua.
+--
+-- Each highlight may set its fg and bg colors, and any attributes
+-- it may desire (italic, bold, etc).
+--
+-- You may also call .clear() on any highlight object to completely
+-- remove the highlight
+--
+-- There are two major methods for using this module:
+-- 1. By directly calling the module itself
+-- 2. By indexing into the highlight group
+--
+-- Examples:
+--
+-- ```
+-- local hl = require 'psoxizsh.util.highlight'
+--
+-- hl {
+--  -- Note that colors are selected from sub objects first (gui.bg), then named top level
+--  -- keys (ctermfg) and lastly unamed top level keys (fg, bg)
+--  { 'Comment', italic = true, gui = { bg = '#0000' }, ctermbg = '#0000' },
+--  -- You may select multiple highlight groups at once
+--  { { 'TmuxSelect', 'TmuxHover' }, underdash = true, fg = '#FFFF', bg = '#FFFF' }
+-- }
+--
+-- hl.clear({ 'Comment', 'TmuxHover', 'TmuxSelect' })
+-- ```
+--
+-- ```
+-- local hl = require 'psoxizsh.util.highlight'
+--
+-- hl.Comment { italic = true, underdot = true }
+-- hl.LspInstallDone { bold = true, gui { bg = '#1E12' } }
+-- hl.TmuxTree.clear()
+-- ```
+
+local cmd = vim.cmd
+local ATTR = {
+  ITEMS = {
+    bold = 1, underline = 1, underlineline = 1,
+    undercurl = 1, underdot = 1, underdash = 1,
+    strikethrough = 1, reverse = 1, inverse = 1,
+    italic = 1, standout = 1, nocombine = 1,
+    NONE = 1,
+  },
+  KEYS = {
+    cterm = 1, ctermfg = 1, ctermbg = 1,
+    gui = 1, guifg = 1, guibg = 1, guisp = 1,
+    font = 1, blend = 1,
+  }
+}
+
+local Highlight = { mt = {} }
+local Hl = { mt = {} }
+
+-- Instantiates a new Hl object assiociated with the given hl_group
+function Hl.new(hl_group)
+  local this = { group = hl_group, clear = Hl.clear }
+  setmetatable(this, Hl.mt)
+
+  return this
+end
+
+-- Deletes the highlight group assiociated with this Hl object
+function Hl.clear(self)
+  cmd(string.format('highlight clear %s', self.group))
+
+  return true
+end
+
+-- Sets the highlight group assiociated with this Hl object
+function Hl.set(self, n_opts)
+  local len, hl_line = 0, 'highlight ' .. self.group
+
+  for key, value in pairs(n_opts) do
+    len = len + 1
+    hl_line = hl_line .. Hl.attr2String(key, value)
+  end
+
+  if len == 0 then return nil end
+
+  cmd(hl_line)
+
+  return true
+end
+
+-- Normalizes the given highlight attributes into a format that can
+-- be presented to ':highlight'
+function Hl.normalize_attrs(_, raw)
+  local gui, cterm = raw.gui or {}, raw.cterm or {}
+
+  return {
+    cterm   = Hl.attr_list('cterm', raw),
+    ctermfg = cterm.fg or raw.ctermfg,
+    ctermbg = cterm.bg or raw.ctermbg,
+    gui     = Hl.attr_list('gui', raw),
+    guifg   = gui.fg or raw.guifg or raw.fg,
+    guibg   = gui.bg or raw.guibg or raw.bg,
+    font    = gui.font or raw.font,
+    blend   = gui.blend or raw.blend,
+  }
+end
+
+-- Generates a list of non nil attribute items, merging the
+-- attrset and attrset[subkey] attributes trees, with the latter
+-- having prefrence
+function Hl.attr_list(subkey, attrset)
+  local list, sub = {}, attrset[subkey] or {}
+
+  for option, _ in pairs(ATTR.ITEMS) do
+    local resolved = sub[option] or attrset[option]
+
+    if resolved ~= nil then table.insert(list, option) end
+  end
+
+  return #list > 0 and list or nil
+end
+
+-- Formats the given attr key,value pair into a string that can be
+-- given to ':highlight'
+function Hl.attr2String(name, value)
+  if ATTR.KEYS[name] and #value > 0 then
+    local v = value
+    if type(v) == 'table' then
+      v = table.concat(value, ',')
+    end
+
+    return string.format(' %s=%s', name, v)
+  else
+    return ''
+  end
+end
+
+-- Sets the highlight group assiociated with this Hl object
+function Hl.mt.__call(self, args)
+  local n_opts = Hl.normalize_attrs(self, args)
+
+  return Hl.set(self, n_opts)
+end
+
+-- Instantiates a new Highlight object
+function Highlight.new()
+  local this = { clear = Highlight.clear }
+  setmetatable(this, Highlight.mt)
+
+  return this
+end
+
+-- Sets the given highlight group(s)
+function Highlight.set(args)
+  local group = args[1] or args.group
+
+  if type(group) == 'table' then
+    local result = true
+    for _, g in ipairs(group) do
+      -- Failure is sticky, always record a failure if any group fails
+      if not Hl.new(g):set(args) and result then result = false end
+    end
+
+    return result
+  elseif type(group) == 'string' then
+    return Hl.new(group):set(args)
+  end
+end
+
+-- Clears the given highlight group.
+--
+-- Note this is closer to disabling the highlight group than it is to
+-- resetting it to defaults
+function Highlight.clear(group)
+  if type(group) == 'table' then
+    local result = true
+    for _, g in ipairs(group) do
+      -- Failure is sticky, always record a failure if any group fails
+      if not Hl.new(g):clear() and result then result = false end
+    end
+
+    return result
+  elseif type(group) == 'string' then
+    return Hl.new(group):clear()
+  end
+end
+
+-- Create a new Hl with the given name that can be called with a set
+-- of highlight attrs to create / overwrite a highlight group
+function Highlight.mt.__index(_, group)
+  return Hl.new(group)
+end
+
+-- Create highlight group(s), taking either a list or single attrset
+function Highlight.mt.__call(_, args)
+  if args.group or type(args[1]) == 'string' then
+    return Highlight.set(args)
+  else
+    for _, attrset in ipairs(args) do
+      Highlight.set(attrset)
+    end
+  end
+end
+
+return Highlight.new()

--- a/nvim/lua/psoxizsh/util/init.lua
+++ b/nvim/lua/psoxizsh/util/init.lua
@@ -1,0 +1,49 @@
+
+local Util = { mt = {} }
+local Lazy = { mt = {} }
+
+local Submodules = {
+  mload = 'psoxizsh.util.mload',
+}
+
+function Util.new()
+  local this = { _submodules = Util.submodules() }
+  setmetatable(this, Util.mt)
+
+  return this
+end
+
+function Util.submodules()
+  local modules = {}
+
+  for key, mod in pairs(Submodules) do
+    modules[key] = Lazy.new(mod)
+  end
+
+  return modules
+end
+
+function Util.mt.__index(self, key)
+  for _, submod in pairs(self._submodules) do
+    if submod[key] then return submod[key] end
+  end
+
+  return nil
+end
+
+function Lazy.new(mod_name)
+  local this = { _module = false, _mod_name = mod_name }
+  setmetatable(this, Lazy.mt)
+
+  return this
+end
+
+function Lazy.mt.__index(self, key)
+  if not self._module then
+    self._module = require(self._mod_name)
+  end
+
+  return self._module[key]
+end
+
+return Util.new()

--- a/nvim/lua/psoxizsh/util/mload.lua
+++ b/nvim/lua/psoxizsh/util/mload.lua
@@ -1,8 +1,8 @@
 
-local Util = {}
+local M = {}
 
 -- Reload a given module, returning the result of loading it.
-function Util.mreload(module)
+function M.mreload(module)
   if package.loaded[module] then
     package.loaded[module] = nil
   end
@@ -11,8 +11,8 @@ function Util.mreload(module)
 end
 
 -- Try reloading the given module, returning ok, module
-function Util.try_mreload(module)
-  return pcall(Util.mreload, module)
+function M.try_mreload(module)
+  return pcall(M.mreload, module)
 end
 
 -- Try reloading the given config module, returning either
@@ -26,7 +26,7 @@ end
 --
 -- It the latter cases, *configuration will not be reloaded*, this is
 -- primaraily meant for inline, static configuration
-function Util.try_mconfig(module)
+function M.try_mconfig(module)
   if type(module) ~= "string" then
     module = type(module) == "function" and module() or module
     module = type(module) == "table" and module or {}
@@ -34,7 +34,7 @@ function Util.try_mconfig(module)
     return module
   end
 
-  local ok, config = Util.try_mreload(module)
+  local ok, config = M.try_mreload(module)
   config = type(config) == "function" and config() or config
 
   return (ok and type(config) == "table") and config or {}
@@ -50,13 +50,13 @@ end
 -- 4. fn() --> table
 --
 -- It the latter cases, *configuration will not be reloaded*, this is
--- primaraily meant for inline, static configuration
+-- primarily meant for inline, static configuration
 --
 -- Note: the config returned from the given module may optionally
 -- set 'no_defaults = true' to opt out of the merging
-function Util.mconfig(module, defaults)
-  module = Util.try_mconfig(module)
-  defaults = Util.try_mconfig(defaults)
+function M.mconfig(module, defaults)
+  module = M.try_mconfig(module)
+  defaults = M.try_mconfig(defaults)
 
   if module.no_defaults then
     return module
@@ -65,4 +65,4 @@ function Util.mconfig(module, defaults)
   end
 end
 
-return Util
+return M

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -27,10 +27,14 @@ set -g status-right '#T #[fg=yellow,bold]#(uptime -p)#[default] #[fg=cyan,bold]%
 set -g set-titles on
 setw -g aggressive-resize on
 setw -g monitor-activity on
-# The following three makes italics work in tmux
+
 set -g xterm-keys on
-set -g default-terminal "xterm-256color"
-set -as terminal-overrides ',xterm*:sitm=\E[3m'
+# Correctly set up terminal for truecolor support
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ',xterm-256color:Tc'
+
+# Fix :h 'autoread' in Vim
+set -g focus-events on
 
 # Refresh status line every 5 seconds
 set -g status-interval 5

--- a/zshrc
+++ b/zshrc
@@ -90,7 +90,6 @@ plugins=(
 ( which rsync &>/dev/null ) && plugins+=( rsync )
 ( which aws &>/dev/null ) && plugins+=( aws )
 ( which rust &>/dev/null ) && plugins+=( rust )
-( which cargo &>/dev/null ) && plugins+=( cargo )
 ( which jq &>/dev/null ) && plugins+=( jsontools )
 ( which encode64 &>/dev/null ) && plugins+=( encode64 )
 ( which docker-compose &>/dev/null ) && plugins+=( docker-compose )


### PR DESCRIPTION
This is a series of small fixes of various bits of psoxizsh, including:

- `zshrc`
- `tmux`
- `nvim`

Generally speaking, there's nothing too important buried in this PR, but below is a short listing of changes, broken down by category.

## `zshrc`

Quoting commit:

> zshrc: remove plugins.cargo
> 
> as the upstream has merged its functionality into plugins.rust, which is
already set.
> 
> See ohmyzsh/ohmyzsh#10270 , ohmyzsh/ohmyzsh@89a740b

## `tmux.conf`

Fixes to our tmux settings, namely:

1. Enabling truecolor (24bit) support

	This has been a real pain, and we've each had hacky workarounds that _"fixed"_ the problem for our various setup(s). No longer, this change properly enables truecolor support by using the `tmux>2.6` special terminal, `tmux-256color`. Next, we force 24bit color for users that _had_ an xterm-256color `TERM` before attaching to tmux.

	We may eventually add more terminals, (e.g `,*256col*:Tc` for all terms that contain the phrase '256col'), but this should fix it for 95% of existing terminals

2. Fixing the autoread feature of n/vim

	This is effectively a way for the terminal to communicate focus events, which n/vim listens for to perform certain tasks, most importantly for us, triggering a resync of buffers to file contents. This allows buffers like git fugitive to update on focus, which is useful when performing git operations in other panes.

## `nvim`

Various changes and tidying:

- Move termguicolors into `pre` (as it now actually does something)
- Add `psoxizsh/util/highlight` for interacting with `:highlight`s
- Simplifying the code behind `psoxizsh/autocmd`, and dropping support for `neovim<0.7.0`
- Misc. fixes and formatting