### PR TITLE
UI Improvements for Neovim >0.7

### DIFF
--- a/nvim/lua/psoxizsh/init.lua
+++ b/nvim/lua/psoxizsh/init.lua
@@ -7,7 +7,7 @@ local function psoxizsh_early_config()
 
   -- Set global color scheme var
   if not g.my_color_scheme then
-    g.my_color_scheme = 'one'
+    g.my_color_scheme = 'onedarkpro'
   end
 
   -- Color settings

--- a/nvim/lua/psoxizsh/plugins/config/notify.lua
+++ b/nvim/lua/psoxizsh/plugins/config/notify.lua
@@ -1,0 +1,21 @@
+return function()
+  local notify, util = require 'notify', require 'psoxizsh.util'
+  local loaded = _G._psoxizsh_plug_config_notify_loaded
+
+  local defaults = {
+    background_colour = "#000000",
+    timeout = 2000,
+    top_down = false,
+  }
+
+  notify.setup(util.mconfig('config.notify', defaults))
+
+  -- Set notify as the default Neovim notification service
+  -- However, weird stuff happens if we set this multiple times
+  -- so guard against that
+  if not loaded then
+    vim.notify = notify
+    _G._psoxizsh_plug_config_notify_loaded = true
+  end
+
+end

--- a/nvim/lua/psoxizsh/plugins/config/onedark.lua
+++ b/nvim/lua/psoxizsh/plugins/config/onedark.lua
@@ -1,0 +1,21 @@
+return function()
+  local odp, util = require 'onedarkpro', require 'psoxizsh.util'
+
+  local defaults = {
+    plugins = { all = true },
+    styles = {
+      comments = 'italic',
+    },
+    options = {
+      bold            = true,
+      italic          = true,
+      underline       = true,
+      undercurl       = true,
+    },
+  }
+
+  if not vim.g.my_color_scheme then vim.g.my_color_scheme = 'onedarkpro' end
+
+  odp.setup(util.mconfig('config.onedark', defaults))
+end
+

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -18,6 +18,11 @@ local plugins = {
       as = 'vimp'
   },
 
+  -- Color themes
+  { 'olimorris/onedarkpro.nvim',
+      config = require 'psoxizsh.plugins.config.onedark'
+  },
+
   -- Text alignment
   { 'junegunn/vim-easy-align' },
   { 'tmsvg/pear-tree',
@@ -104,14 +109,9 @@ local plugins = {
   { 'junegunn/fzf.vim',
       config = require 'psoxizsh.plugins.config.fzf'
   },
+  { 'romainl/vim-cool' },
   { 'adelarsq/vim-matchit' },
   { 'mox-mox/vim-localsearch' },
-
-  -- Color themes
-  { 'rakr/vim-one',
-      config = function() vim.cmd(string.format('colorscheme %s', vim.g.my_color_scheme or 'one')) end
-  },
-  { 'romainl/vim-cool' },
 
   -- Tmux integration for pane movement
   { 'christoomey/vim-tmux-navigator',

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -55,7 +55,7 @@ local plugins = {
   },
   { 'akinsho/bufferline.nvim',
       as = 'bufferline',
-      tag = 'v1.*',
+      tag = 'v2.*',
       requires = { 'kyazdani42/nvim-web-devicons' },
       after = 'vimp',
       config = require 'psoxizsh.plugins.config.bufferline'

--- a/nvim/lua/psoxizsh/plugins/plug.lua
+++ b/nvim/lua/psoxizsh/plugins/plug.lua
@@ -23,6 +23,12 @@ local plugins = {
       config = require 'psoxizsh.plugins.config.onedark'
   },
 
+  -- Pretty vim.notify
+  { 'rcarriga/nvim-notify',
+      tag = 'v3.*',
+      config = require 'psoxizsh.plugins.config.notify'
+  },
+
   -- Text alignment
   { 'junegunn/vim-easy-align' },
   { 'tmsvg/pear-tree',


### PR DESCRIPTION
Couple improvements we can make now that we're not supporting 'old' versions like 0.5 anymore.

## onedarkpro

A much needed facelift for Neovim. Keeps most of the same stylistic choices of `vim-one`, but with significantly better support for many of the plugins we use.

This one is very customizable, so I encourage users to take a look at https://github.com/olimorris/onedarkpro.nvim#wrench-configuration if they want to make changes. Almost everything is configurable to some degree, down to individual highlight groups. 

## Bufferline v2

A bunch, mostly new features in config setup, but feel free to take a look: https://github.com/akinsho/bufferline.nvim/compare/v1.2.0...v2.12.0

## Notify

A nicer `vim.notify` interface, which is increasingly used by many plugins as the reporting/log mechanism.

Use `:Notifications` to access previous messages instead of the normal `:messages`.